### PR TITLE
Readme - correct invalid JSON

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1122,7 +1122,7 @@ browserify -t coffeeify \
 "browserify": {
   "transform": [
     "coffeeify",
-    ["browserify-ngannotate", {"ext": ".coffee", bar: true}]
+    ["browserify-ngannotate", {"ext": ".coffee", "bar": true}]
   ]
 }
 ```


### PR DESCRIPTION
A JSON example snippet is missing quotes on the keys, making it invalid JSON.
