### PR TITLE
fix(security): update hmr example deps

### DIFF
--- a/example/hmr/package.json
+++ b/example/hmr/package.json
@@ -1,8 +1,9 @@
 {
   "name": "browserify-hmr-example",
   "dependencies": {
-    "browserify-hmr": "~0.2.2",
-    "ecstatic": "~0.8.0"
+    "browserify-hmr": "^0.3.6",
+    "ecstatic": "^3.1.1",
+    "watchify": "^3.9.0"
   },
   "scripts": {
     "watch": "watchify -p browserify-hmr main.js -o public/bundle.js -dv",


### PR DESCRIPTION
Updated `ecstatic` in the HMR example to resolve a security issue flagged by github.

See https://nvd.nist.gov/vuln/detail/CVE-2016-10703.

Also updated other deps in the example to latest and tested locally for good measure.