### PR TITLE
Clarify search path

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -374,7 +374,7 @@ Instead of resolving packages from an array of system search paths like how
 `$PATH` works on the command line, node's mechanism is local by default.
 
 If you `require('./foo.js')` from `/beep/boop/bar.js`, node will
-look for `./foo.js` in `/beep/boop/foo.js`. Paths that start with a `./` or
+look for `foo.js` in `/beep/boop`. Paths that start with a `./` or
 `../` are always local to the file that calls `require()`.
 
 If however you require a non-relative name such as `require('xyz')` from


### PR DESCRIPTION
In `readme.markdown`, it states:

> If you `require('./foo.js')` from `/beep/boop/bar.js`, node will
> look for `./foo.js` in `/beep/boop/foo.js`. Paths that start with a `./` or
> `../` are always local to the file that calls `require()`.

But I don't think it makes sense to say it searches for
`foo.js` in `foo.js` here, so I've updated it to read:

> If you `require('./foo.js')` from `/beep/boop/bar.js`, node will
> look for `foo.js` in `/beep/boop`. Paths that start with a `./` or
> `../` are always local to the file that calls `require()`.

Not sure if you want it to be `/beep/boop/` rather than `/beep/boop`?
