### PR TITLE
Add note that NODE_PATH is not supported by browserify

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1293,7 +1293,8 @@ This is because your application is more tightly coupled to a runtime
 environment configuration so there are more moving parts and your application
 will only work when your environment is setup correctly.
 
-node and browserify both support but discourage the use of `$NODE_PATH`.
+browserify supports `opts.paths` (although it is discouraged),
+but does not support `$NODE_PATH`.
 
 ## non-javascript assets
 


### PR DESCRIPTION
browserify doesn't implicitly set opts.paths to NODE_PATH anymore
unlike stated previously in this documentation. For background see:

* <https://github.com/browserify/resolve/issues/39#issuecomment-306223854>
* <https://github.com/browserify/resolve/pull/47>
* <https://github.com/browserify/browserify/issues/1626>